### PR TITLE
find: define silent and verbose flags

### DIFF
--- a/lib/find.js
+++ b/lib/find.js
@@ -23,15 +23,31 @@ exports.builder = function(yargs) {
   }).option('token', {
     alias: 't',
     describe: 'The GitHub auth token (instead of user/password).',
+  }).option('silent', {
+    describe: 'Omit messages about the operation (limit responses to data).',
+  }).option('verbose', {
+    alias: 'v',
+    describe: 'Return the whole issues object (not including function defs).',
   });
 };
 
 exports.handler = function(argv, options) {
   var opts = options || {};
   var _console = opts.console || console;
+  // Shim the console log call with our own.
+  _console.lg = _console.log;
+  _console.log = function() {
+    return argv.silent ? null : _console.lg.apply(this, arguments);
+  };
+  _console.log('Searching for issues...');
   return find(argv, options).then(function(issues) {
-    _console.log(JSON.stringify(issues));
+    _console.log('Found %s issues: ', _.keys(issues).length);
+    // Use pre-shim log; do not silent this output.
+    _console.lg(JSON.stringify(issues));
     return Promise.resolve(issues);
+  }).catch(function(err) {
+    // Do not silence failures!
+    return _console.lg(err);
   });
 };
 
@@ -66,16 +82,30 @@ function find(argv, options) {
       var range = new Date();
       range.setDate(range.getDate() - age);
       debug('range: ', range);
-      var matches = _.map(issues, function(issue) {
+      var matches = _.mapValues(issues, function(issue) {
+        var result = null;
         var updatedAt = new Date(issue.updatedAt);
         if (updatedAt < range) {
-          return issue;
+          result = _(issue).omitBy(_.isNil).omitBy(_.isFunction);
+          if (!argv.verbose) {
+            result = result.pick([
+              'id',
+              'number',
+              'url',
+              'title',
+              'state',
+              'assignee',
+              'assignees',
+              'createdAt',
+              'updatedAt',
+            ]);
+          }
+          return result.value();
         } else {
           return null;
         }
       });
-      return Promise.resolve(_(matches).omitBy(_.isNil)
-        .omitBy(_.isFunction).value());
+      return Promise.resolve(_.omitBy(matches, _.isNil));
     }).catch(function(err) {
       debug('error: %s', err);
       return Promise.reject(err);

--- a/test/fixtures/fake-console.js
+++ b/test/fixtures/fake-console.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = Console;
+
+function Console() {
+  this.calls = [];
+}
+
+Console.prototype.log = function() {
+  this.calls.push({ args: arguments });
+};

--- a/test/fixtures/fake-octokat.js
+++ b/test/fixtures/fake-octokat.js
@@ -9,12 +9,34 @@ function Octokat() {
   var now = new Date();
   this.issues = [
     {
+      id: 1234567,
+      number: 1,
+      url: 'https://github.com/magicOrg/fakeRepo',
+      title: 'Does\'nt pop enough!',
       state: 'open',
+      assignee: null,
+      assignees: [],
+      createdAt: new Date().setDate(now.getDate() - 36),
       updatedAt: new Date().setDate(now.getDate() - 35),
+      extraProperty: 'an extra field to test verbosity',
+      fnProperty: function() {
+        return 'A function that we do not want in our returned issues!';
+      },
     },
     {
+      id: 4567893,
+      number: 2,
+      url: 'https://github.com/magicOrg/fakeRepo',
+      title: 'Needs more cowbell',
       state: 'open',
+      assignee: null,
+      assignees: [],
+      createdAt: new Date().setDate(now.getDate() - 71),
       updatedAt: new Date().setDate(now.getDate() - 70),
+      extraProperty: 'an extra field to test verbosity',
+      fnProperty: function() {
+        return 'A function that we do not want in our returned issues!';
+      },
     },
   ];
   this.repoInfo = {

--- a/test/test-find.js
+++ b/test/test-find.js
@@ -1,40 +1,106 @@
 'use strict';
 
+var Promise = require('bluebird');
 var _ = require('lodash');
 var debug = require('../lib/debug')('test-find');
 var find = require('../lib/find').handler;
 var tap = require('tap');
 
 tap.test('find issues', function(t) {
+  t.test('simple issue tests', function(t) {
 
-  t.test('older than the default value', function(t) {
-    return issueAssert(t, {
+    var defaultAge = basicChecks(t, 'default age', 2, {
       token: 'fakeToken',
-      repo: 'org/fakeRepo',
-    }, 2);
-  });
+      repo: 'magicOrg/fakeRepo',
+    });
 
-  t.test('older than a specified value', function(t) {
-    return issueAssert(t, {
+    var nonDefaultAge = basicChecks(t, 'non-default age', 1, {
       token: 'fakeToken',
-      repo: 'org/fakeRepo',
+      repo: 'magicOrg/fakeRepo',
       age: 60,
-    }, 1);
+    });
+    return Promise.map([defaultAge, nonDefaultAge], function(issues) {
+      _.each(issues, function(issue) {
+        t.notOk(issue['extraProperty'], 'no extra properties');
+        t.notOk(issue['fnProperty'], 'no function properties');
+      });
+      return null;
+    }).finally(t.end);
   });
 
-  function issueAssert(t, args, count) {
+  t.test('verbose issue tests', function(t) {
+    var defaultAge = basicChecks(t, 'default age', 2, {
+      token: 'fakeToken',
+      repo: 'magicOrg/fakeRepo',
+      verbose: true,
+    });
+
+    var nonDefaultAge = basicChecks(t, 'non-default age', 1, {
+      token: 'fakeToken',
+      repo: 'magicOrg/fakeRepo',
+      verbose: true,
+      age: 60,
+    });
+
+    return Promise.map([defaultAge, nonDefaultAge], function(issues) {
+      _.each(issues, function(issue) {
+        t.ok(issue['extraProperty'], 'no extra properties');
+        t.notOk(issue['fnProperty'], 'no function properties');
+      });
+      return null;
+    }).finally(t.end);
+  });
+
+  t.test('silent flag', function(t) {
+    return consoleChecks(t, 'silent', 1, {
+      token: 'fakeToken',
+      repo: 'magicOrg/fakeRepo',
+      verbose: true,
+      silent: true,
+    }).then(function(fakeConsole) {
+      var args = fakeConsole.calls[0].args;
+      t.assert(args, 'arguments exist');
+      t.notOk(_.includes(args, 'Searching for issues...'), 'no human output');
+    }).finally(t.end);
+  });
+
+  t.test('no silent flag', function(t) {
+    return consoleChecks(t, 'loud', 3, {
+      token: 'fakeToken',
+      repo: 'magicOrg/fakeRepo',
+      verbose: true,
+    }).then(function(fakeConsole) {
+      var args = fakeConsole.calls[0].args;
+      t.assert(args, 'arguments exist');
+      t.ok(_.includes(args, 'Searching for issues...'), 'human output found');
+    }).finally(t.end);
+  });
+
+  function basicChecks(t, label, count, args) {
+    var Console = require('./fixtures/fake-console');
     var opts = {
       octokatCtor: require('./fixtures/fake-octokat'),
-      console: {
-        // Silence console output for tests.
-        log: function() {},
-      },
+      console: new Console(),
     };
     return find(args, opts).then(function(issues) {
+      t.comment(label);
       t.assert(issues, 'issues exist');
       debug('issues: ', issues);
       t.equals(_.keys(issues).length, count, 'correct number of issues found');
-      t.end();
+      return issues;
+    });
+  }
+
+  function consoleChecks(t, label, count, args) {
+    var Console = require('./fixtures/fake-console');
+    var opts = {
+      octokatCtor: require('./fixtures/fake-octokat'),
+      console: new Console(),
+    };
+    return find(args, opts).then(function() {
+      debug('console calls: %j', opts.console.calls);
+      t.equals(opts.console.calls.length, count, 'number of calls match');
+      return opts.console;
     });
   }
 


### PR DESCRIPTION
The '--silent' flag will make omit messages to the user
The '--verbose' flag will print the entirety of the issue object,
except for top-level function properties (which are a part of the
Octokat API).