### PR TITLE
Enable use as executable or importable module

### DIFF
--- a/bin/closing-time.js
+++ b/bin/closing-time.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+'use strict';
+
+require('yargs')
+  .command(require('../lib/find'))
+  .help().argv;

--- a/index.js
+++ b/index.js
@@ -2,6 +2,4 @@
 
 'use strict';
 
-require('yargs')
-  .command(require('./lib/find'))
-  .help().argv;
+exports.find = require('./lib/find').handler;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tap --coverage --coverage-report=cobertura ./test/test-*"
   },
   "bin": {
-    "closing-time": "./index.js"
+    "closing-time": "./bin/closing-time.js"
   },
   "dependencies": {
     "bluebird": "^3.4.6",


### PR DESCRIPTION
You can now import closing-time as a module for other applications
as well as a command-line tool.